### PR TITLE
Add custom filter and missing field diagnostic settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,13 +138,27 @@ Leave this empty if `"apiKey"` in the Anki-Connect configuration is set to `null
 
 * `anki-editor.invalidFieldDiagnostics`: Enable or disable error detection of field names in template replacements.
 
+* `anki-editor.missingFieldDiagnostics`: Enable or disable error detection of missing field names in template replacements.
+
 * `anki-editor.invalidFilterDiagnostics`: Enable or disable error detection of filter names in template replacements.
 
 * `anki-editor.customFieldNames`: Add extra field names that will be allowed in template replacements, and will be used for completion suggestions.
-This can be used when an Anki add-on is installed that adds extra special fields.
+  This can be used when an Anki add-on is installed that adds extra special fields.
 
 * `anki-editor.customFilterNames`: Add extra filter names that will be allowed in template replacements, and will be used for completion suggestions.
-This can be used when an Anki add-on is installed that adds extra filters.
+  This can be used when an Anki add-on is installed that adds extra filters.
+  A custom filter can be defined as a string or an object.
+
+  Example:
+  ```json
+  "anki-editor.customFilterNames": [
+      "custom-filter1",
+      {
+          "name": "custom-filter2",
+          "fieldRequired": true
+      }
+  ]
+  ```
 
 * `anki-editor.checkJsLevel`: Sets the level of type checking for embedded Javascript type errors.
   The values `"on"`, `"default"` and `"off"` correspond to the values `true`, `undefined` and `false` of the [`checkJs`](https://www.typescriptlang.org/tsconfig#checkJs) property in the TypeScript compiler options.

--- a/package.json
+++ b/package.json
@@ -183,7 +183,8 @@
               {
                 "type": "string",
                 "pattern": "^[^#^/\\s:{}\"]+$",
-                "patternErrorMessage": "Custom filter names can't contain spaces or # ^ / : \" { }"
+                "patternErrorMessage": "Custom filter names can't contain spaces or # ^ / : \" { }",
+                "examples": ["custom-filter"]
               },
               {
                 "type": "object",
@@ -192,7 +193,8 @@
                     "type": "string",
                     "pattern": "^[^#^/\\s:{}\"]+$",
                     "patternErrorMessage": "Custom filter names can't contain spaces or # ^ / : \" { }",
-                    "description": "Name of the custom filter."
+                    "description": "Name of the custom filter.",
+                    "examples": ["custom-filter"]
                   },
                   "fieldRequired": {
                     "type": "boolean",
@@ -200,17 +202,16 @@
                     "description": "Specifies if a field name is required when this filter is used.\nDefaults to true."
                   }
                 },
-                "required": ["name"]
+                "required": ["name"],
+                "examples": [
+                  {
+                    "name": "custom-filter",
+                    "fieldRequired": true
+                  }
+                ]
               }
             ]
           },
-          "default": [
-            "custom-filter",
-            {
-              "name": "custom-filter",
-              "fieldRequired": true
-            }
-          ],
           "markdownDescription": "Extra filters to show in completion suggestions, and to ignore when checking for errors.\nA custom filter can be defined as a string such as `\"custom-filter\"` or an object such as `{ \"name\": \"custom-filter\", \"fieldRequired\": \"true\" }`."
         },
         "anki-editor.checkJsLevel": {

--- a/package.json
+++ b/package.json
@@ -161,7 +161,7 @@
           "title": "Missing Field Diagnostics",
           "type": "boolean",
           "default": true,
-          "description": "Show errors for replacements without a field name."
+          "description": "Show an error when a replacement does not contain a field name."
         },
         "anki-editor.customFieldNames": {
           "title": "Custom Fields",
@@ -212,7 +212,7 @@
               }
             ]
           },
-          "markdownDescription": "Extra filters to show in completion suggestions, and to ignore when checking for errors.\nA custom filter can be defined as a string such as `\"custom-filter\"` or an object such as `{ \"name\": \"custom-filter\", \"fieldRequired\": \"true\" }`."
+          "markdownDescription": "Extra filters to show in completion suggestions, and to ignore when checking for errors.\nA custom filter can be defined as a string such as `\"custom-filter\"` or an object such as `{ \"name\": \"custom-filter\", \"fieldRequired\": true }`."
         },
         "anki-editor.checkJsLevel": {
           "title": "Javascript type checking level",

--- a/package.json
+++ b/package.json
@@ -172,12 +172,40 @@
           "title": "Custom Filters",
           "type": "array",
           "items": {
-            "type": "string",
-            "pattern": "^[^#^/\\s:{}\"]+$",
-            "patternErrorMessage": "Custom filter names can't contain spaces or # ^ / : \" { }"
+            "type": ["string", "object"],
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^[^#^/\\s:{}\"]+$",
+                "patternErrorMessage": "Custom filter names can't contain spaces or # ^ / : \" { }"
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "pattern": "^[^#^/\\s:{}\"]+$",
+                    "patternErrorMessage": "Custom filter names can't contain spaces or # ^ / : \" { }",
+                    "description": "Name of the custom filter."
+                  },
+                  "fieldRequired": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Specifies if a field name is required when this filter is used.\nDefaults to true."
+                  }
+                },
+                "required": ["name"]
+              }
+            ]
           },
-          "default": [],
-          "description": "Extra filter names to show in completion suggestions, and to ignore when checking errors."
+          "default": [
+            "custom-filter",
+            {
+              "name": "custom-filter",
+              "fieldRequired": true
+            }
+          ],
+          "markdownDescription": "Extra filters to show in completion suggestions, and to ignore when checking for errors.\nA custom filter can be defined as a string such as `\"custom-filter\"` or an object such as `{ \"name\": \"custom-filter\", \"fieldRequired\": \"true\" }`."
         },
         "anki-editor.checkJsLevel": {
           "title": "Javascript type checking level",

--- a/package.json
+++ b/package.json
@@ -157,6 +157,12 @@
           "default": true,
           "description": "Show errors for filter names that are not built into Anki."
         },
+        "anki-editor.missingFieldDiagnostics": {
+          "title": "Missing Field Diagnostics",
+          "type": "boolean",
+          "default": true,
+          "description": "Show errors for replacements without a field name."
+        },
         "anki-editor.customFieldNames": {
           "title": "Custom Fields",
           "type": "array",

--- a/src/language-service/anki-builtin.ts
+++ b/src/language-service/anki-builtin.ts
@@ -9,6 +9,10 @@ export interface BuiltIn {
     htmlDescription?: boolean;
 }
 
+export type BuiltInFilter = BuiltIn & {
+    fieldRequired: boolean;
+}
+
 // Built-in special fields
 
 export const specialFieldsList: readonly BuiltIn[] = [
@@ -62,7 +66,7 @@ export const specialFieldsList: readonly BuiltIn[] = [
 
 // Built-in filters
 
-export const builtinFiltersList: readonly BuiltIn[] = [
+export const builtinFiltersList: readonly BuiltInFilter[] = [
     {
         name: "tts",
         description: "Converts the value of the field in this replacement to spoken words.\n\n" +
@@ -72,14 +76,16 @@ export const builtinFiltersList: readonly BuiltIn[] = [
             "### Options Example\n\n" +
             "The options `voices` and `speed` can optionally be used to set the voice used for conversion, and the speed at which the audio is played.\n\n" +
             quotedCodeBlock(TEMPLATE_LANGUAGE_ID, "{{tts en_US voices=Microsoft_George speed=1.0:Field}}") +
-            docsLink("Text to Speech", "https://docs.ankiweb.net/templates/fields.html#text-to-speech")
+            docsLink("Text to Speech", "https://docs.ankiweb.net/templates/fields.html#text-to-speech"),
+        fieldRequired: true
     },
     {
         name: "tts-voices",
         description: "Displays a list of tts languages and voices available on the system the card or card preview is rendered on.\n\n" +
             "### Example\n\n" +
             quotedCodeBlock(TEMPLATE_LANGUAGE_ID, "{{tts-voices:}}") +
-            docsLink("Text to Speech", "https://docs.ankiweb.net/templates/fields.html#text-to-speech")
+            docsLink("Text to Speech", "https://docs.ankiweb.net/templates/fields.html#text-to-speech"),
+        fieldRequired: false
     },
     {
         name: "cloze",
@@ -92,14 +98,16 @@ export const builtinFiltersList: readonly BuiltIn[] = [
                     front: "This is a **[...]** cloze deletion.",
                     back: "This is a **sample** cloze deletion."
                 }) +
-            docsLink("Cloze Deletion", "https://docs.ankiweb.net/editing.html#cloze-deletion")
+            docsLink("Cloze Deletion", "https://docs.ankiweb.net/editing.html#cloze-deletion"),
+        fieldRequired: true
     },
     {
         name: "cloze-only",
         description: "When used in combination with the `tts` filter, only the deleted text will be read.\n\n" +
             "### Example\n\n" +
             quotedCodeBlock(TEMPLATE_LANGUAGE_ID, "{{tts en_US:cloze-only:Field}}") +
-            docsLink("Text to Speech", "https://docs.ankiweb.net/templates/fields.html#text-to-speech")
+            docsLink("Text to Speech", "https://docs.ankiweb.net/templates/fields.html#text-to-speech"),
+        fieldRequired: true
     },
     {
         name: "hint",
@@ -107,7 +115,8 @@ export const builtinFiltersList: readonly BuiltIn[] = [
             filterExample("{{hint:Field}}", "This is some hint text.", "[Field](https://docs.ankiweb.net/templates/fields.html#hint-fields)") + "\n\n" +
             "When the 'Field' text is clicked, the field's content is revealed:\n\n" +
             quotedCodeBlock("text", "This is some hint text.") +
-            docsLink("Hint Fields", "https://docs.ankiweb.net/templates/fields.html#hint-fields")
+            docsLink("Hint Fields", "https://docs.ankiweb.net/templates/fields.html#hint-fields"),
+        fieldRequired: true
     },
     {
         name: "type",
@@ -115,13 +124,15 @@ export const builtinFiltersList: readonly BuiltIn[] = [
             "Displays the correct and incorrect letters of the user's input when also used on the back of the card template.\n\n" +
             "### Example\n\n" +
             quotedCodeBlock(TEMPLATE_LANGUAGE_ID, "{{type:Field}}") +
-            docsLink("Checking Your Answer", "https://docs.ankiweb.net/templates/fields.html#checking-your-answer")
+            docsLink("Checking Your Answer", "https://docs.ankiweb.net/templates/fields.html#checking-your-answer"),
+        fieldRequired: true
     },
     {
         name: "text",
         description: "Displays the source content of the field without any formatting.\n\n" +
             filterExample("{{text:Field}}", "**Bold** and *Italic* text.", "Bold and Italic text.", true) +
-            docsLink("HTML Stripping", "https://docs.ankiweb.net/templates/fields.html#html-stripping")
+            docsLink("HTML Stripping", "https://docs.ankiweb.net/templates/fields.html#html-stripping"),
+        fieldRequired: true
     },
     {
         name: "furigana",
@@ -129,21 +140,24 @@ export const builtinFiltersList: readonly BuiltIn[] = [
             "Ruby characters will be displayed above the logographic characters.\n\n" +
             rubyFilterExample("furigana") +
             docsLink("Ruby Characters", "https://docs.ankiweb.net/templates/fields.html#ruby-characters"),
-        htmlDescription: true
+        htmlDescription: true,
+        fieldRequired: true
     },
     {
         name: "kana",
         description: "Allows for the use of logographic and ruby characters in a field.\n\n" +
             "Only the ruby characters will be displayed.\n\n" +
             rubyFilterExample("kana") +
-            docsLink("Additional Ruby Character Filters", "https://docs.ankiweb.net/templates/fields.html#additional-ruby-character-filters")
+            docsLink("Additional Ruby Character Filters", "https://docs.ankiweb.net/templates/fields.html#additional-ruby-character-filters"),
+        fieldRequired: true
     },
     {
         name: "kanji",
         description: "Allows for the use of logographic and ruby characters in a field.\n\n" +
             "Only the logographic characters will be displayed.\n\n" +
             rubyFilterExample("kanji") +
-            docsLink("Additional Ruby Character Filters", "https://docs.ankiweb.net/templates/fields.html#additional-ruby-character-filters")
+            docsLink("Additional Ruby Character Filters", "https://docs.ankiweb.net/templates/fields.html#additional-ruby-character-filters"),
+        fieldRequired: true
     }
 ];
 

--- a/src/language-service/anki-custom.ts
+++ b/src/language-service/anki-custom.ts
@@ -15,8 +15,8 @@ const getItemsFromConfig = (section: "customFieldNames" | "customFilterNames"): 
 }
 
 export const getCustomFieldNames = (): string[] => getItemsFromConfig("customFieldNames")
-    .filter((possibleFielName): possibleFielName is string => typeof possibleFielName === "string")
-    .filter(customFielName => customFielName.match(/^[^#^/\s:{}\"]+([^:{}\s\"]|\s(?!\s*(}}|$)))*$/));
+    .filter((possibleFieldName): possibleFieldName is string => typeof possibleFieldName === "string")
+    .filter(customFieldName => customFieldName.match(/^[^#^/\s:{}\"]+([^:{}\s\"]|\s(?!\s*(}}|$)))*$/));
 
 export const getCustomFilterItems = (): CustomFilter[] => getItemsFromConfig("customFilterNames")
     .filter((possibleFilter): possibleFilter is string | CustomFilter => typeof possibleFilter === "string" || typeof possibleFilter === "object" && "name" in possibleFilter && typeof possibleFilter.name === "string")

--- a/src/language-service/feature-providers/template-diagnostics-collection.ts
+++ b/src/language-service/feature-providers/template-diagnostics-collection.ts
@@ -121,8 +121,8 @@ export default class TemplateDiagnosticsProvider extends LanguageFeatureProvider
 
                 // Check if replacement contains any filters that explicitly state a field is not required
                 const fieldOptional = replacement.type === AstItemType.replacement &&
-                    replacement.filterSegments.some(({ filter }) => filter && validFiltersMap.get(filter.content)?.fieldRequired === false)
-                    || !config.get("missingFieldDiagnostics");
+                    (replacement.filterSegments.some(({ filter }) => filter && validFiltersMap.get(filter.content)?.fieldRequired === false)
+                    || !config.get("missingFieldDiagnostics"));
 
                 // Check if field exists in model
                 const { field } = replacement.fieldSegment;

--- a/src/language-service/feature-providers/template-diagnostics-collection.ts
+++ b/src/language-service/feature-providers/template-diagnostics-collection.ts
@@ -121,7 +121,8 @@ export default class TemplateDiagnosticsProvider extends LanguageFeatureProvider
 
                 // Check if replacement contains any filters that explicitly state a field is not required
                 const fieldOptional = replacement.type === AstItemType.replacement &&
-                    replacement.filterSegments.some(({ filter }) => filter && validFiltersMap.get(filter.content)?.fieldRequired === false);
+                    replacement.filterSegments.some(({ filter }) => filter && validFiltersMap.get(filter.content)?.fieldRequired === false)
+                    || !config.get("missingFieldDiagnostics");
 
                 // Check if field exists in model
                 const { field } = replacement.fieldSegment;


### PR DESCRIPTION
## Changelog

### Updated setting for custom filters.
Custom filters can now be defined as strings or objects. When adding a custom filter as object the boolean property `fieldRequired` can be set to specify if the replacement must contain a field name when this filter is used. 

The only downside of this change is that custom filters can now only be set directly in json format and not in the setting UI. This is because VSCode won't show an input box for a settings list that can contain both strings and objects.

Example of new custom filters json configuration: 
```json
"anki-editor.customFilterNames": [
      "custom-filter1",
      {
          "name": "custom-filter2",
          "fieldRequired": false
      }
  ]
```

### Added missing field diagnostic toggle
Added a setting to disable diagnostics for missing field names in replacements globally.

Resolves #1 