### PR TITLE
Fix parsing uri with special caracters

### DIFF
--- a/src/note-types/lookup-note-type.ts
+++ b/src/note-types/lookup-note-type.ts
@@ -12,7 +12,7 @@ export const lookupNoteType = async (uri: vscode.Uri, ankiConnect: AnkiConnect):
 
     if (parts.length === 0) {
         // Uri is root of note types folder, return list of note type directories
-        console.log("fetching modelNames");
+        // console.log("fetching modelNames");
         const modelNames = await ankiConnect.getModelNames();
 
         const rootDir = new Directory("");

--- a/src/note-types/uri-parser.ts
+++ b/src/note-types/uri-parser.ts
@@ -38,6 +38,8 @@ export const partsToUri = (parts: string[]): vscode.Uri => {
                 parts[2] = escapeText(parts[2]);
     }
 
-    const path = resultParts.join("/");
+    const path = resultParts
+        .map(part => encodeURIComponent(part))
+        .join("/");
     return vscode.Uri.parse(`${ANKI_EDITOR_SCHEME}${path}`);
 }


### PR DESCRIPTION
## Changelog
- Fixed parsing of card uri's with special characters in note types or card template names. Resolves #3 