### PR TITLE
Html formatting escaping

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -102,7 +102,7 @@ export function activate(context: vscode.ExtensionContext) {
 	const templateReferenceProvider = new TemplateReferenceProvider(embeddedHandler);
 	const templateCodeActionProvider = new TemplateCodeActionProvider(embeddedHandler, ankiModelDataProvider);
 	const templateDocumentColorProvider = new TemplateDocumentColorProvider(embeddedHandler);
-	const templateDocumentFormattingEditProvider = new TemplateDocumentFormattingEditProvider(embeddedHandler);
+	const templateDocumentFormattingEditProvider = new TemplateDocumentFormattingEditProvider(embeddedHandler, virtualDocumentProvider);
 	const templateDocumentRangeFormattingEditProvider = new TemplateDocumentRangeFormattingEditProvider(embeddedHandler);
 	const templateFoldingRangeProvider = new TemplateFoldingRangeProvider(embeddedHandler);
 

--- a/src/language-service/escape-html.ts
+++ b/src/language-service/escape-html.ts
@@ -15,7 +15,7 @@ export const unescapeHtml = (escapedHtml: string) => escapedHtml
     .replace(/&quot;/g, '"')
     .replace(/&gt;/g, ">")
     .replace(/&lt;/g, "<")
-    .replace(/"&amp;"/g, "&")
+    .replace(/"&amp;"/g, "&");
 
 const convertTemplateRegions = (inputHtmlContent: string, templateRegions: LanguageRegion[], escape: boolean): string => {
     const outputHtmlContent = templateRegions.reduce((accumulated, templateRegion) => {
@@ -40,7 +40,7 @@ const convertTemplateRegions = (inputHtmlContent: string, templateRegions: Langu
 }
 
 export const escapeTemplateRegions = (inputHtmlContent: string, templateRegions: LanguageRegion[]): string =>
-    convertTemplateRegions(inputHtmlContent, templateRegions, true)
+    convertTemplateRegions(inputHtmlContent, templateRegions, true);
 
 export const unescapeTemplateRegions = (inputHtmlContent: string, templateRegions: LanguageRegion[]): string =>
-    convertTemplateRegions(inputHtmlContent, templateRegions, false)
+    convertTemplateRegions(inputHtmlContent, templateRegions, false);

--- a/src/language-service/escape-html.ts
+++ b/src/language-service/escape-html.ts
@@ -1,0 +1,46 @@
+import { LanguageRegion, replaceRange } from "./language-regions";
+
+// https://stackoverflow.com/a/6234804
+export const escapeHtml = (html: string) => html
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#039;")
+    .replace(/\//g, "&#47;");
+
+export const unescapeHtml = (escapedHtml: string) => escapedHtml
+    .replace(/&#47;/g, "\/")
+    .replace(/&#039;/g, "'")
+    .replace(/&quot;/g, '"')
+    .replace(/&gt;/g, ">")
+    .replace(/&lt;/g, "<")
+    .replace(/"&amp;"/g, "&")
+
+const convertTemplateRegions = (inputHtmlContent: string, templateRegions: LanguageRegion[], escape: boolean): string => {
+    const outputHtmlContent = templateRegions.reduce((accumulated, templateRegion) => {
+        const templateRegionContent = templateRegion.blankSurroundings
+            ? templateRegion.content.substring(templateRegion.start, templateRegion.end)
+            : templateRegion.content;
+        
+        const convertedRegionContent = escape
+            ? escapeHtml(templateRegionContent)
+            : unescapeHtml(templateRegionContent);
+
+        const newHtml = replaceRange(accumulated.html, templateRegion.start + accumulated.offset, templateRegion.end + accumulated.offset, convertedRegionContent);
+        const newOffset = accumulated.offset + (convertedRegionContent.length - templateRegionContent.length);
+
+        return { html: newHtml, offset: newOffset };
+    }, {
+        html: inputHtmlContent,
+        offset: 0
+    });
+
+    return outputHtmlContent.html;
+}
+
+export const escapeTemplateRegions = (inputHtmlContent: string, templateRegions: LanguageRegion[]): string =>
+    convertTemplateRegions(inputHtmlContent, templateRegions, true)
+
+export const unescapeTemplateRegions = (inputHtmlContent: string, templateRegions: LanguageRegion[]): string =>
+    convertTemplateRegions(inputHtmlContent, templateRegions, false)

--- a/src/language-service/feature-providers/embedded-functions.ts
+++ b/src/language-service/feature-providers/embedded-functions.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import { ANKI_EDITOR_EMBEDDED_SCHEME } from '../../constants';
-import { LanguageId } from '../../models/embedded-languages';
+import { LanguageId, VirtualLanguageId } from '../../models/embedded-languages';
 
-export const createVirtualUri = (languageId: LanguageId, fileExtension: string, originalUri: vscode.Uri) => 
+export const createVirtualUri = (languageId: LanguageId | VirtualLanguageId, fileExtension: string, originalUri: vscode.Uri) => 
     vscode.Uri.parse(`${ANKI_EDITOR_EMBEDDED_SCHEME}${languageId}${originalUri.path}.${fileExtension}`);

--- a/src/language-service/feature-providers/template-document-formatting-edit-provider.ts
+++ b/src/language-service/feature-providers/template-document-formatting-edit-provider.ts
@@ -1,7 +1,16 @@
 import * as vscode from 'vscode';
 import LanguageFeatureProviderBase from './language-feature-provider-base';
+import EmbeddedHandler from '../embedded-handler';
+import VirtualDocumentProvider from '../virtual-documents-provider';
+import { escapeTemplateRegions, unescapeTemplateRegions } from '../escape-html';
+import { getReplacementTemplateLanguageRegions } from '../language-regions';
+import { createVirtualUri } from './embedded-functions';
 
 export default class TemplateDocumentFormattingEditProvider extends LanguageFeatureProviderBase implements vscode.DocumentFormattingEditProvider {
+
+    constructor(embeddedHandler: EmbeddedHandler, private virtualDocumentProvider: VirtualDocumentProvider) {
+        super(embeddedHandler)
+    }
 
     async provideDocumentFormattingEdits(document: vscode.TextDocument, options: vscode.FormattingOptions, token: vscode.CancellationToken): Promise<vscode.TextEdit[] | null | undefined> {
         
@@ -9,14 +18,38 @@ export default class TemplateDocumentFormattingEditProvider extends LanguageFeat
 
         if (!embeddedDocument)
             return;
-        
-        const textEdits = await vscode.commands.executeCommand<vscode.TextEdit[]>(
-            'vscode.executeFormatDocumentProvider',
-            embeddedDocument.virtualUri,
-            options
-        );
 
-        return textEdits;
+        // escape certain html characters before sending the document to VSCode's document format provider
+        const templateRegions = getReplacementTemplateLanguageRegions(embeddedDocument.content, false);
+        const escapedDocumentContent = escapeTemplateRegions(embeddedDocument.content, templateRegions);
+
+        const escapedDocumentUri = createVirtualUri("html-escaped", "html", embeddedDocument.virtualUri);
+        this.virtualDocumentProvider.setDocumentContent(escapedDocumentUri, escapedDocumentContent);
+
+        const formatTextEdits: vscode.TextEdit[] = [];
+        try {
+            formatTextEdits.push(...await vscode.commands.executeCommand<vscode.TextEdit[]>(
+                'vscode.executeFormatDocumentProvider',
+                escapedDocumentUri,
+                options
+            ));
+        }
+        catch (error) {
+            throw error;
+        }
+        finally {
+            this.virtualDocumentProvider.deleteUri(escapedDocumentUri);
+        }
+        
+        // unescape replacement templates content in text edits
+        formatTextEdits.forEach(formatTextEdit => {
+            const textEditContent = formatTextEdit.newText;
+            const formattedTemplateRegions = getReplacementTemplateLanguageRegions(textEditContent, false);
+            const unescapedTextEditContent = unescapeTemplateRegions(textEditContent, formattedTemplateRegions);
+            formatTextEdit.newText = unescapedTextEditContent;
+        });
+
+        return formatTextEdits;
     }
 
 }

--- a/src/language-service/feature-providers/template-document-formatting-edit-provider.ts
+++ b/src/language-service/feature-providers/template-document-formatting-edit-provider.ts
@@ -23,7 +23,7 @@ export default class TemplateDocumentFormattingEditProvider extends LanguageFeat
         const templateRegions = getReplacementTemplateLanguageRegions(embeddedDocument.content, false);
         const escapedDocumentContent = escapeTemplateRegions(embeddedDocument.content, templateRegions);
 
-        const escapedDocumentUri = createVirtualUri("html-escaped", "html", embeddedDocument.virtualUri);
+        const escapedDocumentUri = createVirtualUri("html-escaped", "html", document.uri);
         this.virtualDocumentProvider.setDocumentContent(escapedDocumentUri, escapedDocumentContent);
 
         const formatTextEdits: vscode.TextEdit[] = [];

--- a/src/models/embedded-languages.ts
+++ b/src/models/embedded-languages.ts
@@ -2,10 +2,15 @@ import { TEMPLATE_LANGUAGE_ID } from "../constants";
 
 export const embeddedLanguages = {
     "html": "html",
-    "html-escaped": "html",
     "css": "css",
     "javascript": "js",
     [TEMPLATE_LANGUAGE_ID]: "template.anki"
 } as const;
 
 export type LanguageId = keyof typeof embeddedLanguages;
+
+export const virtualLanguages = {
+    "html-escaped": "html"
+} as const;
+
+export type VirtualLanguageId = keyof typeof virtualLanguages;

--- a/src/models/embedded-languages.ts
+++ b/src/models/embedded-languages.ts
@@ -2,6 +2,7 @@ import { TEMPLATE_LANGUAGE_ID } from "../constants";
 
 export const embeddedLanguages = {
     "html": "html",
+    "html-escaped": "html",
     "css": "css",
     "javascript": "js",
     [TEMPLATE_LANGUAGE_ID]: "template.anki"


### PR DESCRIPTION
- Added escaping of some html characters inside a replacement before forwarding a template document's content to VSCode's formatter. Fixes #9 